### PR TITLE
Fix the issue of tooltip text overlapping with other mod

### DIFF
--- a/Contents/mods/TransmogDefinitiveEdition/media/lua/client/Transmog/InvContextMenu.lua
+++ b/Contents/mods/TransmogDefinitiveEdition/media/lua/client/Transmog/InvContextMenu.lua
@@ -1,4 +1,10 @@
 local iconTexture = getTexture("media/ui/TransmogIcon.png")
+local textMenu = getText("IGUI_TransmogDE_Context_Menu")
+local textTransmogrify = getText("IGUI_TransmogDE_Context_Transmogrify")
+local textHide = getText("IGUI_TransmogDE_Context_Hide")
+local textDefault = getText("IGUI_TransmogDE_Context_Default")
+local textColor = getText("IGUI_TransmogDE_Context_Color")
+local textTexture = getText("IGUI_TransmogDE_Context_Texture")
 
 local addEditTransmogItemOption = function(player, context, items)
   local playerObj = getSpecificPlayer(player)
@@ -15,22 +21,22 @@ local addEditTransmogItemOption = function(player, context, items)
   end
 
   if tostring(#items) == "1" and clothing then
-    local option = context:addOption("Transmog Menu");
+    local option = context:addOption(textMenu);
     option.iconTexture = iconTexture
     local menuContext = context:getNew(context);
     context:addSubMenu(option, menuContext);
 
-    menuContext:addOption("Transmogrify", clothing, function()
+    menuContext:addOption(textTransmogrify, clothing, function()
       TransmogListViewer.OnOpenPanel(clothing)
       TransmogDE.triggerUpdate()
     end);
 
-    menuContext:addOption("Hide Item", clothing, function()
+    menuContext:addOption(textHide, clothing, function()
       TransmogDE.setClothingHidden(clothing)
       TransmogDE.triggerUpdate()
     end);
 
-		menuContext:addOption("Reset to Default", clothing, function()
+		menuContext:addOption(textDefault, clothing, function()
       TransmogDE.setItemToDefault(clothing)
       TransmogDE.triggerUpdate()
     end);
@@ -47,7 +53,7 @@ local addEditTransmogItemOption = function(player, context, items)
 
     local tmogClothingItemAsset = TransmogDE.getClothingItemAsset(tmogScriptItem)
     if tmogClothingItemAsset:getAllowRandomTint() then
-      menuContext:addOption("Change Color", clothing, function()
+      menuContext:addOption(textColor, clothing, function()
         local modal = ColorPickerModal:new(clothing, playerObj);
         modal:initialise();
         modal:addToUIManager();
@@ -66,7 +72,7 @@ local addEditTransmogItemOption = function(player, context, items)
     -- TmogPrint('getTextureChoices()', tmogClothingItemAsset:getTextureChoices())
     -- TmogPrint('getBaseTextures()', tmogClothingItemAsset:getBaseTextures())
     if textureChoices and (textureChoices:size() > 1) then
-      menuContext:addOption("Change Texture", clothing, function()
+      menuContext:addOption(textTexture, clothing, function()
         local modal = TexturePickerModal:new(clothing, playerObj, textureChoices);
         modal:initialise();
         modal:addToUIManager();

--- a/Contents/mods/TransmogDefinitiveEdition/media/lua/client/Transmog/ToolTipInv.lua
+++ b/Contents/mods/TransmogDefinitiveEdition/media/lua/client/Transmog/ToolTipInv.lua
@@ -8,6 +8,10 @@ function ISToolTipInv:render()
   end
 
   local itemModData = TransmogDE.getItemTransmogModData(self.item)
+  if itemModData.transmogTo == self.item:getScriptItem():getFullName() then
+    return old_render(self)
+  end
+
   local name = itemModData.transmogTo and getItemNameFromFullType(itemModData.transmogTo) or "Hidden"
   local tmogTooltipText = {
     "Transmog to: " .. name,
@@ -15,22 +19,26 @@ function ISToolTipInv:render()
 
   local font = UIFont[getCore():getOptionTooltipFont()];
   local lineSpacing = self.tooltip:getLineSpacing()
-  local height = self.tooltip:getHeight()
-  local newHeight = height + (#tmogTooltipText * lineSpacing) + (lineSpacing / 2)
+  local y = self.tooltip:getHeight()
+  local height = (#tmogTooltipText * lineSpacing) + (lineSpacing / 2)
 
   local old_setHeight = ISToolTipInv.setHeight
 
+  local isFirstTimeSetHeight = true
   self.setHeight = function(self, h, ...)
-    h = newHeight
-    self.keepOnScreen = false
+    if isFirstTimeSetHeight then
+      isFirstTimeSetHeight = false
+      y = h
+      h = h + height
+    end
     return old_setHeight(self, h, ...)
   end
 
   local old_drawRectBorder = ISToolTipInv.drawRectBorder
   self.drawRectBorder = function(self, ...)
     for _, text in ipairs(tmogTooltipText) do
-      self.tooltip:DrawText(font, text, 5, height, 1, 0.6, 0, 1)
-      height = height + lineSpacing
+      self.tooltip:DrawText(font, text, 5, y, 1, 0.6, 0, 1)
+      y = y + lineSpacing
     end
     old_drawRectBorder(self, ...)
   end

--- a/Contents/mods/TransmogDefinitiveEdition/media/lua/client/Transmog/ToolTipInv.lua
+++ b/Contents/mods/TransmogDefinitiveEdition/media/lua/client/Transmog/ToolTipInv.lua
@@ -12,9 +12,11 @@ function ISToolTipInv:render()
     return old_render(self)
   end
 
-  local name = itemModData.transmogTo and getItemNameFromFullType(itemModData.transmogTo) or "Hidden"
+  local text = itemModData.transmogTo
+    and getText("IGUI_TransmogDE_Tooltip_TransmogTo", getItemNameFromFullType(itemModData.transmogTo))
+    or getText("IGUI_TransmogDE_Tooltip_TransmogHidden")
   local tmogTooltipText = {
-    "Transmog to: " .. name,
+    text,
   }
 
   local font = UIFont[getCore():getOptionTooltipFont()];

--- a/Contents/mods/TransmogDefinitiveEdition/media/lua/client/Transmog/UI/TransmogListViewer.lua
+++ b/Contents/mods/TransmogDefinitiveEdition/media/lua/client/Transmog/UI/TransmogListViewer.lua
@@ -90,7 +90,7 @@ function ISItemsListTable:createChildren()
 end
 
 function ISItemsListTable:sendItemToTransmog(scriptItem)
-  local text = 'Transmogged to' .. getItemNameFromFullType(scriptItem:getFullName())
+  local text = getText("IGUI_TransmogDE_Text_TransmoggedTo", getItemNameFromFullType(scriptItem:getFullName()))
   HaloTextHelper.addText(getPlayer(), text, HaloTextHelper.getColorGreen())
   TransmogDE.setItemTransmog(self.viewer.itemToTmog, scriptItem)
   TransmogDE.forceUpdateClothing(self.viewer.itemToTmog)

--- a/Contents/mods/TransmogDefinitiveEdition/media/lua/shared/Translate/CN/IG_UI_CN.txt
+++ b/Contents/mods/TransmogDefinitiveEdition/media/lua/shared/Translate/CN/IG_UI_CN.txt
@@ -1,0 +1,11 @@
+IGUI_CN = {
+    IGUI_TransmogDE_Tooltip_TransmogTo = "幻化: %1",
+    IGUI_TransmogDE_Tooltip_TransmogHidden = "幻化: <已隐藏>",
+    IGUI_TransmogDE_Context_Menu = "装备幻化",
+    IGUI_TransmogDE_Context_Transmogrify = "幻化外观",
+    IGUI_TransmogDE_Context_Hide = "隐藏外观",
+    IGUI_TransmogDE_Context_Default = "解除幻化",
+    IGUI_TransmogDE_Context_Color = "调整颜色",
+    IGUI_TransmogDE_Context_Texture = "切换纹理",
+    IGUI_TransmogDE_Text_TransmoggedTo = "已幻化为%1",
+}

--- a/Contents/mods/TransmogDefinitiveEdition/media/lua/shared/Translate/EN/IG_UI_EN.txt
+++ b/Contents/mods/TransmogDefinitiveEdition/media/lua/shared/Translate/EN/IG_UI_EN.txt
@@ -1,0 +1,11 @@
+IGUI_EN = {
+    IGUI_TransmogDE_Tooltip_TransmogTo = "Transmog to: %1",
+    IGUI_TransmogDE_Tooltip_TransmogHidden = "Transmog to: <Hidden>",
+    IGUI_TransmogDE_Context_Menu = "Transmog Menu",
+    IGUI_TransmogDE_Context_Transmogrify = "Transmogrify",
+    IGUI_TransmogDE_Context_Hide = "Hide Item",
+    IGUI_TransmogDE_Context_Default = "Reset to Default",
+    IGUI_TransmogDE_Context_Color = "Change Color",
+    IGUI_TransmogDE_Context_Texture = "Change Texture",
+    IGUI_TransmogDE_Text_TransmoggedTo = "Transmogged to %1",
+}


### PR DESCRIPTION
Also hide the tooltip if the item is not transmogged. 

Tested with
[Dynamic Backpack Upgrades](https://steamcommunity.com/sharedfiles/filedetails/?id=2996978365)
[Item stats display](https://steamcommunity.com/sharedfiles/filedetails/?id=2845265699)

Before:
![before1](https://github.com/user-attachments/assets/a1bd60c1-cc96-4ceb-8089-e5563bb42852) ![before2](https://github.com/user-attachments/assets/f10b32d7-1b8c-4208-9fb8-885216a80149)

After:
![after1](https://github.com/user-attachments/assets/54537b3d-a35c-4b39-a502-32d13e89fdb6) ![after2](https://github.com/user-attachments/assets/346f70ab-100f-4392-9757-690abd9854c7)

